### PR TITLE
add debug output in the command line

### DIFF
--- a/command.json
+++ b/command.json
@@ -5,7 +5,7 @@
   "version": "0.2",
   "image": "anzhao1981/exiftool:v0.1",
   "type": "docker",
-  "command-line": "exiftool -X /input/RESOURCES/CR2/* > /output/metadata.xml",
+  "command-line": "exiftool -X /input/RESOURCES/CR2/* > /output/metadata.xml 2> /output/error.log && echo \"Listing /output contents:\" >> /output/error.log && ls -lh /output >> /output/error.log && echo \"Checking if metadata.xml exists...\" >> /output/error.log && if [ -f /output/metadata.xml ]; then echo \"metadata.xml exists and is ready.\" >> /output/error.log; else echo \"metadata.xml NOT FOUND!\" >> /output/error.log; fi",
   "override-entrypoint": true,
   "mounts": [
     {


### PR DESCRIPTION
Explicitly checks if the metadata file exists or not.